### PR TITLE
Fix: max recursion limit

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -266,7 +266,7 @@ wheels = [
 
 [[package]]
 name = "loam-iiif"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1 by implementing a regular loop instead of recursion.

## Notes

- Instead of `seen_manifests` and `seen_collections`, just `manifest_ids` and `collection_ids` are used to keep track of visited items.
- Refactored some code into helper functions for normalizing data

## Other options considered

- Though possible to update the [recursion limit](https://docs.python.org/3/library/sys.html#sys.setrecursionlimit), it's impossible to know the size of a given collection beforehand
- Increasing the page size via the `size` param would rectify the issue, but (1) given loam's function in the OSDP, we can't ensure users will do that and (2) for very large collections, a large page size still may not work.

See related [repodev_planning_and_docs issue](https://github.com/nulib/repodev_planning_and_docs/issues/5381)