### PR TITLE
Add an option for the maximum number of manifests to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ loamiiif "https://api.dc.library.northwestern.edu/api/v2/collections?as=iiif" --
 loamiiif "https://api.dc.library.northwestern.edu/api/v2/collections?as=iiif" --format json --output manifests.json --download-manifests --json-output-dir ./manifests_json
 ```
 
+7. Set a maximum number of manifests to retrieve
+
+```bash
+loamiiif "https://api.dc.library.northwestern.edu/api/v2/collections?as=iiif" --max-manifests=42
+```
+
 Example debug output (truncated):
 
 ```

--- a/src/loam_iiif/cli.py
+++ b/src/loam_iiif/cli.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import sys
-from typing import List
 
 import click
 from rich.console import Console
@@ -66,6 +65,13 @@ def sanitize_filename(name: str) -> str:
     show_default=True,
     help="Directory to save the manifest JSON files.",
 )
+@click.option(
+    "--max-manifests",
+    "-m",
+    type=click.INT,
+    default=None,
+    help="Maximum number of manifests to retrieve. If not specified, all manifests are retrieved.",
+)
 def main(
     url: str,
     output: str,
@@ -73,6 +79,7 @@ def main(
     debug: bool,
     download_manifests: bool,
     json_output_dir: str,
+    max_manifests: int,
 ):
     """
     Traverse a IIIF collection URL and retrieve manifests.
@@ -93,7 +100,7 @@ def main(
 
     try:
         with IIIFClient() as client:
-            manifests, collections = client.get_manifests_and_collections_ids(url)
+            manifests, collections = client.get_manifests_and_collections_ids(url, max_manifests)
     except Exception as e:
         logger.error(f"An error occurred: {e}")
         sys.exit(1)


### PR DESCRIPTION
Closes #3 

Adds a `--max-manifests` option:

```bash
# "Africa Embracing Obama" collection
loamiiif "https://api.dc.library.northwestern.edu/api/v2/collections/ecacd539-fe38-40ec-bbc0-590acee3d4f2?as=iiif" --max-manifests=12


{
  "manifests": [
    "https://api.dc.library.northwestern.edu/api/v2/works/67bb90c0-c25f-43f0-871b-3afd5a839733?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/d6b104e3-dfee-42bd-bec7-371036523818?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/128b091f-fb12-41fe-8d7b-491591bf754b?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/eac5aa8f-5ecb-4e79-a4d0-23b02543fd09?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/08b65de6-7bba-4778-8967-0efbc42d496c?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/8c655231-7aed-41b3-ad90-c2becfe08528?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/2e417ca3-9ea0-4aad-ac05-4f4da85959fd?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/37419624-abe9-445a-be21-ac8217155549?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/754484f4-7874-4c66-b8aa-4968d6e48df9?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/e0eecb1a-a3e1-4360-801b-e81dfcd718de?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/b5e1fc15-1d29-4d28-9cfc-4b8adfaf5ea9?as=iiif",
    "https://api.dc.library.northwestern.edu/api/v2/works/4694f055-7d7c-458e-bba6-f223cded2f54?as=iiif"
  ],
  "collections": [
    "https://api.dc.library.northwestern.edu/api/v2/collections/ecacd539-fe38-40ec-bbc0-590acee3d4f2?as=iiif&page=2",
    "https://api.dc.library.northwestern.edu/api/v2/collections/ecacd539-fe38-40ec-bbc0-590acee3d4f2?as=iiif"
  ]
}
```

_Based off of branch `issue-1/recursion`, which would need to be merged via PR #2 before this_