### PR TITLE
Fixes manifest parsing bug, refactor terminology from chunk to parse individual manifests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "loam-iiif"
-version = "0.1.5"
+version = "0.1.6"
 description = "A command-line tool for fetching IIIF Collections on the Web."
 readme = "README.md"
 authors = [{ name = "Brendan Quinn", email = "brendan-quinn@northwestern.edu" }]
@@ -29,11 +29,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
-dev = [
-    "twine>=6.0.1",
-    "pytest>=7.4.0",
-    "pytest-cov>=6.0.0",
-]
+dev = ["twine>=6.0.1", "pytest>=7.4.0", "pytest-cov>=6.0.0"]
 
 [tool.coverage.run]
 source = ["src"]
@@ -44,7 +40,7 @@ omit = [
     "*/__pycache__/*",
     "*/venv/*",
     "*/.venv/*",
-    "example.py"
+    "example.py",
 ]
 
 [tool.coverage.report]

--- a/src/loam_iiif/cli.py
+++ b/src/loam_iiif/cli.py
@@ -15,6 +15,17 @@ from rich.table import Table
 
 from .iiif import IIIFClient
 
+try:
+    from importlib.metadata import version
+except ImportError:
+    # Python < 3.8 fallback
+    from importlib_metadata import version
+
+try:
+    __version__ = version("loam-iiif")
+except Exception:
+    __version__ = "unknown"
+
 # Initialize Rich Console for logging (outputs to stderr)
 console = Console(stderr=True)
 
@@ -39,6 +50,7 @@ def sanitize_filename(name: str) -> str:
 
 
 @click.group()
+@click.version_option(version=__version__, prog_name="loam-iiif")
 def cli():
     """IIIF collection and manifest processing tools."""
     pass

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -523,9 +523,18 @@ def test_main_entry_point(cli_runner):
 
 def test_main_entry_point_actual(cli_runner):
     """Test the actual main entry point function using the CLI group"""
-    result = cli_runner.invoke(cli)
+    result = cli_runner.invoke(cli, ['--help'])
     assert result.exit_code == 0
     assert "Usage: cli [OPTIONS] COMMAND" in result.output
+    assert "IIIF collection and manifest processing tools" in result.output
+
+def test_version_option(cli_runner):
+    """Test the --version option displays version information"""
+    result = cli_runner.invoke(cli, ['--version'])
+    assert result.exit_code == 0
+    assert "loam-iiif, version" in result.output
+    # Verify it shows a version number (either actual version or "unknown")
+    assert ("0.1.5" in result.output) or ("unknown" in result.output)
 
 def test_collect_image_size_options(cli_runner, mock_iiif_client):
     """Test that image size options are correctly passed to get_manifest_images"""

--- a/test/test_iiif.py
+++ b/test/test_iiif.py
@@ -1155,23 +1155,23 @@ def test_parent_collection_label_extraction_v2():
         
     client.fetch_json = mock_fetch_json
 
-    # Create chunks and verify parent collection label is extracted
-    chunks = client.create_manifest_chunks([
+    # Parse data and verify parent collection label is extracted
+    parsed_data = client.create_manifest_data([
         "https://digital.library.villanova.edu/Item/vudl:10950/Manifest"
     ])
     
-    assert len(chunks) == 1, "Should create one chunk"
-    chunk = chunks[0]
+    assert len(parsed_data) == 1, "Should create one parsed entry"
+    parsed_item = parsed_data[0]
     
     # Verify parent collection information
-    assert len(chunk["metadata"]["parent_collections"]) == 1, "Should have one parent collection"
-    parent_collection = chunk["metadata"]["parent_collections"][0]
+    assert len(parsed_item["metadata"]["parent_collections"]) == 1, "Should have one parent collection"
+    parent_collection = parsed_item["metadata"]["parent_collections"][0]
     
     assert parent_collection["id"] == "https://digital.library.villanova.edu/Collection/vudl:680115/IIIF"
     assert parent_collection["label"] == "Naturforschenden Vereines in Brünn", "Should extract correct collection label"
     
     # Verify text includes proper parent collection info
-    assert "Part Of: Naturforschenden Vereines in Brünn (https://digital.library.villanova.edu/Collection/vudl:680115/IIIF)" in chunk["text"]
+    assert "Part Of: Naturforschenden Vereines in Brünn (https://digital.library.villanova.edu/Collection/vudl:680115/IIIF)" in parsed_item["text"]
 
 def test_parent_collection_label_extraction_v3():
     """Test extracting parent collection labels from IIIF v3 manifests using 'partOf' field"""
@@ -1197,23 +1197,23 @@ def test_parent_collection_label_extraction_v3():
         
     client.fetch_json = mock_fetch_json
 
-    # Create chunks and verify parent collection label is extracted
-    chunks = client.create_manifest_chunks([
+    # Parse data and verify parent collection label is extracted
+    parsed_data = client.create_manifest_data([
         "https://api.dc.library.northwestern.edu/api/v2/works/test-manifest?as=iiif"
     ])
     
-    assert len(chunks) == 1, "Should create one chunk"
-    chunk = chunks[0]
+    assert len(parsed_data) == 1, "Should create one parsed entry"
+    parsed_item = parsed_data[0]
     
     # Verify parent collection information
-    assert len(chunk["metadata"]["parent_collections"]) == 1, "Should have one parent collection"
-    parent_collection = chunk["metadata"]["parent_collections"][0]
+    assert len(parsed_item["metadata"]["parent_collections"]) == 1, "Should have one parent collection"
+    parent_collection = parsed_item["metadata"]["parent_collections"][0]
     
     assert parent_collection["id"] == "https://api.dc.library.northwestern.edu/api/v2/collections/test-collection?as=iiif"
     assert parent_collection["label"] == "Africa Embracing Obama", "Should extract correct collection label"
     
     # Verify text includes proper parent collection info
-    assert "Part Of: Africa Embracing Obama (https://api.dc.library.northwestern.edu/api/v2/collections/test-collection?as=iiif)" in chunk["text"]
+    assert "Part Of: Africa Embracing Obama (https://api.dc.library.northwestern.edu/api/v2/collections/test-collection?as=iiif)" in parsed_item["text"]
 
 def test_parent_collection_fetch_failure():
     """Test handling when parent collection fetch fails"""
@@ -1240,13 +1240,13 @@ def test_parent_collection_fetch_failure():
 
     # Capture logged warnings
     with patch('logging.Logger.warning') as mock_warning:
-        chunks = client.create_manifest_chunks(["https://example.org/manifest"])
+        parsed_data = client.create_manifest_data(["https://example.org/manifest"])
         
-        assert len(chunks) == 1, "Should still create chunk despite fetch failure"
-        chunk = chunks[0]
+        assert len(parsed_data) == 1, "Should still create parsed entry despite fetch failure"
+        parsed_item = parsed_data[0]
         
         # Should fall back to "Label Unknown"
-        parent_collection = chunk["metadata"]["parent_collections"][0]
+        parent_collection = parsed_item["metadata"]["parent_collections"][0]
         assert parent_collection["label"] == "Parent Collection (Label Unknown)"
         
         # Should log warning about fetch failure
@@ -1296,15 +1296,15 @@ def test_parent_collection_within_list():
         
     client.fetch_json = mock_fetch_json
 
-    chunks = client.create_manifest_chunks(["https://example.org/manifest"])
+    parsed_data = client.create_manifest_data(["https://example.org/manifest"])
     
-    assert len(chunks) == 1, "Should create one chunk"
-    chunk = chunks[0]
+    assert len(parsed_data) == 1, "Should create one parsed entry"
+    parsed_item = parsed_data[0]
     
     # Should have both parent collections
-    assert len(chunk["metadata"]["parent_collections"]) == 2, "Should have two parent collections"
+    assert len(parsed_item["metadata"]["parent_collections"]) == 2, "Should have two parent collections"
     
-    labels = [pc["label"] for pc in chunk["metadata"]["parent_collections"]]
+    labels = [pc["label"] for pc in parsed_item["metadata"]["parent_collections"]]
     assert "First Collection" in labels
     assert "Second Collection" in labels
 
@@ -1330,14 +1330,14 @@ def test_parent_collection_within_object():
         
     client.fetch_json = mock_fetch_json
 
-    chunks = client.create_manifest_chunks(["https://example.org/manifest"])
+    parsed_data = client.create_manifest_data(["https://example.org/manifest"])
     
-    assert len(chunks) == 1, "Should create one chunk"
-    chunk = chunks[0]
+    assert len(parsed_data) == 1, "Should create one parsed entry"
+    parsed_item = parsed_data[0]
     
     # Should extract label from embedded object without additional fetch
-    assert len(chunk["metadata"]["parent_collections"]) == 1, "Should have one parent collection"
-    parent_collection = chunk["metadata"]["parent_collections"][0]
+    assert len(parsed_item["metadata"]["parent_collections"]) == 1, "Should have one parent collection"
+    parent_collection = parsed_item["metadata"]["parent_collections"][0]
     
     assert parent_collection["id"] == "https://example.org/collection"
     assert parent_collection["label"] == "Embedded Collection Label"
@@ -1375,12 +1375,12 @@ def test_parent_collection_complex_label_structures():
         
     client.fetch_json = mock_fetch_json
 
-    chunks = client.create_manifest_chunks(["https://example.org/manifest"])
+    parsed_data = client.create_manifest_data(["https://example.org/manifest"])
     
-    assert len(chunks) == 1, "Should create one chunk"
-    chunk = chunks[0]
+    assert len(parsed_data) == 1, "Should create one parsed entry"
+    parsed_item = parsed_data[0]
     
-    parent_collection = chunk["metadata"]["parent_collections"][0]
+    parent_collection = parsed_item["metadata"]["parent_collections"][0]
     # Should prefer English label over fallback
     assert parent_collection["label"] == "English Label"
 
@@ -1401,16 +1401,16 @@ def test_no_parent_collection():
         
     client.fetch_json = mock_fetch_json
 
-    chunks = client.create_manifest_chunks(["https://example.org/manifest"])
+    parsed_data = client.create_manifest_data(["https://example.org/manifest"])
     
-    assert len(chunks) == 1, "Should create one chunk"
-    chunk = chunks[0]
+    assert len(parsed_data) == 1, "Should create one parsed entry"
+    parsed_item = parsed_data[0]
     
     # Should have empty parent collections list
-    assert chunk["metadata"]["parent_collections"] == []
+    assert parsed_item["metadata"]["parent_collections"] == []
     
     # Text should not include "Part Of" section
-    assert "Part Of:" not in chunk["text"]
+    assert "Part Of:" not in parsed_item["text"]
 
 def test_homepage_extraction_from_related_field():
     """Test homepage extraction from IIIF v2 'related' field"""
@@ -1431,10 +1431,10 @@ def test_homepage_extraction_from_related_field():
         
     client.fetch_json = mock_fetch_json
     
-    chunks = client.create_manifest_chunks(["https://digital.library.villanova.edu/Item/test/Manifest"])
+    parsed_data = client.create_manifest_data(["https://digital.library.villanova.edu/Item/test/Manifest"])
     
-    assert len(chunks) == 1
-    metadata = chunks[0]["metadata"]
+    assert len(parsed_data) == 1
+    metadata = parsed_data[0]["metadata"]
     
     # Should extract homepage from related field
     assert metadata["homepage"] == "https://digital.library.villanova.edu/Item/test"
@@ -1461,10 +1461,10 @@ def test_homepage_extraction_from_metadata_about_field():
         
     client.fetch_json = mock_fetch_json
     
-    chunks = client.create_manifest_chunks(["https://digital.library.villanova.edu/Item/test/Manifest"])
+    parsed_data = client.create_manifest_data(["https://digital.library.villanova.edu/Item/test/Manifest"])
     
-    assert len(chunks) == 1
-    metadata = chunks[0]["metadata"]
+    assert len(parsed_data) == 1
+    metadata = parsed_data[0]["metadata"]
     
     # Should extract homepage from "Permanent Link" in About metadata
     assert metadata["homepage"] == "https://digital.library.villanova.edu/Item/test"
@@ -1495,10 +1495,10 @@ def test_homepage_extraction_priority():
         
     client.fetch_json = mock_fetch_json
     
-    chunks = client.create_manifest_chunks(["https://digital.library.villanova.edu/Item/test/Manifest"])
+    parsed_data = client.create_manifest_data(["https://digital.library.villanova.edu/Item/test/Manifest"])
     
-    assert len(chunks) == 1
-    metadata = chunks[0]["metadata"]
+    assert len(parsed_data) == 1
+    metadata = parsed_data[0]["metadata"]
     
     # Should prefer Permanent Link from metadata over related field
     assert metadata["homepage"] == "https://digital.library.villanova.edu/Item/test-permanent"
@@ -1523,10 +1523,10 @@ def test_rights_extraction_from_attribution():
         
     client.fetch_json = mock_fetch_json
     
-    chunks = client.create_manifest_chunks(["https://digital.library.villanova.edu/Item/test/Manifest"])
+    parsed_data = client.create_manifest_data(["https://digital.library.villanova.edu/Item/test/Manifest"])
     
-    assert len(chunks) == 1
-    metadata = chunks[0]["metadata"]
+    assert len(parsed_data) == 1
+    metadata = parsed_data[0]["metadata"]
     
     # Should extract rights URL from attribution HTML
     assert metadata["rights"] == "https://digital.library.villanova.edu/rights.html"
@@ -1561,10 +1561,10 @@ def test_enhanced_metadata_extraction_combined():
         
     client.fetch_json = mock_fetch_json
     
-    chunks = client.create_manifest_chunks(["https://digital.library.villanova.edu/Item/test/Manifest"])
+    parsed_data = client.create_manifest_data(["https://digital.library.villanova.edu/Item/test/Manifest"])
     
-    assert len(chunks) == 1
-    metadata = chunks[0]["metadata"]
+    assert len(parsed_data) == 1
+    metadata = parsed_data[0]["metadata"]
     
     # Should extract homepage from "Permanent Link" (priority over related)
     assert metadata["homepage"] == "https://digital.library.villanova.edu/Item/test-permanent"
@@ -1597,10 +1597,10 @@ def test_rights_extraction_fallback_when_no_rights_field():
         
     client.fetch_json = mock_fetch_json
     
-    chunks = client.create_manifest_chunks(["https://example.org/manifest"])
+    parsed_data = client.create_manifest_data(["https://example.org/manifest"])
     
-    assert len(chunks) == 1
-    metadata = chunks[0]["metadata"]
+    assert len(parsed_data) == 1
+    metadata = parsed_data[0]["metadata"]
     
     # Should use explicit rights field, not extract from attribution
     assert metadata["rights"] == "http://creativecommons.org/licenses/by/4.0/"
@@ -1631,10 +1631,10 @@ def test_homepage_extraction_with_related_list():
         
     client.fetch_json = mock_fetch_json
     
-    chunks = client.create_manifest_chunks(["https://digital.library.villanova.edu/Item/test/Manifest"])
+    parsed_data = client.create_manifest_data(["https://digital.library.villanova.edu/Item/test/Manifest"])
     
-    assert len(chunks) == 1
-    metadata = chunks[0]["metadata"]
+    assert len(parsed_data) == 1
+    metadata = parsed_data[0]["metadata"]
     
     # Should extract homepage from first item in related list
     assert metadata["homepage"] == "https://digital.library.villanova.edu/Item/test-first"
@@ -1661,10 +1661,10 @@ def test_no_homepage_extraction_when_no_sources():
         
     client.fetch_json = mock_fetch_json
     
-    chunks = client.create_manifest_chunks(["https://digital.library.villanova.edu/Item/test/Manifest"])
+    parsed_data = client.create_manifest_data(["https://digital.library.villanova.edu/Item/test/Manifest"])
     
-    assert len(chunks) == 1
-    metadata = chunks[0]["metadata"]
+    assert len(parsed_data) == 1
+    metadata = parsed_data[0]["metadata"]
     
     # Should remain None when no homepage sources are available
     assert metadata["homepage"] is None
@@ -1705,10 +1705,10 @@ def test_rights_extraction_with_different_html_patterns():
             
         client.fetch_json = mock_fetch_json
         
-        chunks = client.create_manifest_chunks([f"https://example.org/manifest-{i}"])
+        parsed_data = client.create_manifest_data([f"https://example.org/manifest-{i}"])
         
-        assert len(chunks) == 1
-        metadata = chunks[0]["metadata"]
+        assert len(parsed_data) == 1
+        metadata = parsed_data[0]["metadata"]
         
         # Should extract the expected rights URL
         assert metadata["rights"] == test_case["expected"], f"Failed for test case {i}: {test_case['html']}"
@@ -1960,3 +1960,235 @@ def test_non_paginated_collection_with_items():
     # Should work as before
     assert len(manifests) == 3, "Should find 3 manifests in non-paginated collection"
     assert len(collections) == 1, "Should find 1 collection"
+
+def test_northwestern_requiredstatement_dictionary_format():
+    """Test Northwestern's IIIF requiredStatement with dictionary value format (fix for TypeError bug)"""
+    client = IIIFClient(no_cache=True)
+    
+    # This reproduces the Northwestern manifest structure that was causing:
+    # TypeError: expected string or bytes-like object, got 'dict'
+    manifest_data = {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        "id": "https://api.dc.library.northwestern.edu/api/v2/works/4fe8b730-100c-4697-86e4-9fc86c677bba?as=iiif",
+        "type": "Manifest",
+        "label": {
+            "none": ["Baseball Players Practicing"]
+        },
+        "requiredStatement": {
+            "label": {
+                "none": ["Attribution"]
+            },
+            "value": {
+                "none": [
+                    "Courtesy of Northwestern University Libraries",
+                    "The photographs in this collection are owned by Carl Smith, Professor Emeritus at Northwestern University, and are provided for use by its students, faculty and staff, and by other researchers visiting this site. This photograph is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License (https://creativecommons.org/licenses/by-nc/4.0/)."
+                ]
+            }
+        },
+        "partOf": [
+            {
+                "id": "https://api.dc.library.northwestern.edu/api/v2/collections/a74462b0-5ab4-496a-97a8-b963bb19b7df?as=iiif",
+                "type": "Collection",
+                "label": {
+                    "none": ["Collection of Carl Smith"]
+                }
+            }
+        ],
+        "homepage": [
+            {
+                "id": "https://dc.library.northwestern.edu/items/4fe8b730-100c-4697-86e4-9fc86c677bba",
+                "type": "Text",
+                "label": {
+                    "none": ["Homepage"]
+                },
+                "format": "text/html"
+            }
+        ]
+    }
+    
+    def mock_fetch_json(url):
+        return manifest_data
+        
+    client.fetch_json = mock_fetch_json
+    
+    # This would have failed with "TypeError: expected string or bytes-like object, got 'dict'"
+    # before the fix in _extract_iiif_text usage for rights extraction
+    parsed_data = client.create_manifest_data(["https://api.dc.library.northwestern.edu/api/v2/works/4fe8b730-100c-4697-86e4-9fc86c677bba?as=iiif"])
+    
+    assert len(parsed_data) == 1, "Should create one parsed entry"
+    
+    parsed_item = parsed_data[0]
+    metadata = parsed_item["metadata"]
+    
+    # Verify core fields are extracted correctly
+    assert metadata["title"] == "Baseball Players Practicing"
+    assert metadata["id"] == "https://api.dc.library.northwestern.edu/api/v2/works/4fe8b730-100c-4697-86e4-9fc86c677bba?as=iiif"
+    assert metadata["homepage"] == "https://dc.library.northwestern.edu/items/4fe8b730-100c-4697-86e4-9fc86c677bba"
+    
+    # Verify attribution is extracted from requiredStatement dictionary format
+    attribution = metadata["attribution"]
+    assert attribution is not None, "Should extract attribution"
+    assert attribution["label"] == "Attribution"
+    assert "Courtesy of Northwestern University Libraries" in attribution["value"]
+    assert "Carl Smith" in attribution["value"]
+    assert "Creative Commons" in attribution["value"]
+    
+    # Verify parent collection is extracted
+    parent_collections = metadata["parent_collections"]
+    assert len(parent_collections) == 1, "Should find one parent collection"
+    assert parent_collections[0]["id"] == "https://api.dc.library.northwestern.edu/api/v2/collections/a74462b0-5ab4-496a-97a8-b963bb19b7df?as=iiif"
+    assert parent_collections[0]["label"] == "Collection of Carl Smith"
+    
+    # Verify text parsed_item contains expected content
+    text = parsed_item["text"]
+    assert "Baseball Players Practicing" in text
+    assert "Part Of: Collection of Carl Smith" in text
+    assert "Carl Smith" in text
+
+def test_northwestern_requiredstatement_with_rights_extraction():
+    """Test Northwestern's requiredStatement format with HTML content for rights extraction"""
+    client = IIIFClient(no_cache=True)
+    
+    # Northwestern manifest with HTML content in requiredStatement that could contain rights URLs
+    manifest_data = {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        "id": "https://api.dc.library.northwestern.edu/api/v2/works/example?as=iiif",
+        "type": "Manifest",
+        "label": {
+            "none": ["Test Document"]
+        },
+        "requiredStatement": {
+            "label": {
+                "none": ["Attribution"]
+            },
+            "value": {
+                "none": [
+                    'Courtesy of Northwestern University Libraries',
+                    'This material is provided for educational use. For more information see <a href="https://www.library.northwestern.edu/rights.html">Rights Information</a>.'
+                ]
+            }
+        }
+    }
+    
+    def mock_fetch_json(url):
+        return manifest_data
+        
+    client.fetch_json = mock_fetch_json
+    
+    # This tests the specific fix: _extract_iiif_text(raw_attribution, strip_tags=False)
+    # instead of direct regex on dictionary
+    parsed_data = client.create_manifest_data(["https://api.dc.library.northwestern.edu/api/v2/works/example?as=iiif"])
+    
+    assert len(parsed_data) == 1
+    metadata = parsed_data[0]["metadata"]
+    
+    # Should extract rights URL from the HTML in requiredStatement
+    assert metadata["rights"] == "https://www.library.northwestern.edu/rights.html"
+    
+    # Should still extract attribution text
+    attribution = metadata["attribution"]
+    assert attribution is not None
+    assert "Northwestern University Libraries" in attribution["value"]
+
+
+def test_parse_manifest_single_manifest():
+    """Test the new parse_manifest method for individual manifests"""
+    client = IIIFClient(no_cache=True)
+    
+    # Northwestern manifest data
+    manifest_data = {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        "id": "https://api.dc.library.northwestern.edu/api/v2/works/1b607dac-481a-43e8-a11f-3818a0b10e16?as=iiif",
+        "type": "Manifest",
+        "label": {
+            "none": ["Single Manifest Test"]
+        },
+        "requiredStatement": {
+            "label": {
+                "none": ["Attribution"]
+            },
+            "value": {
+                "none": ["Courtesy of Northwestern University Libraries"]
+            }
+        },
+        "partOf": [
+            {
+                "id": "https://api.dc.library.northwestern.edu/api/v2/collections/example?as=iiif",
+                "type": "Collection",
+                "label": {
+                    "none": ["Test Collection"]
+                }
+            }
+        ],
+        "homepage": [
+            {
+                "id": "https://dc.library.northwestern.edu/items/1b607dac-481a-43e8-a11f-3818a0b10e16",
+                "type": "Text",
+                "label": {
+                    "none": ["Homepage"]
+                },
+                "format": "text/html"
+            }
+        ]
+    }
+    
+    def mock_fetch_json(url):
+        if url == "https://api.dc.library.northwestern.edu/api/v2/works/1b607dac-481a-43e8-a11f-3818a0b10e16?as=iiif":
+            return manifest_data
+        return {}
+        
+    client.fetch_json = mock_fetch_json
+    
+    # Test the new single manifest method
+    parsed_item = client.parse_manifest(
+        "https://api.dc.library.northwestern.edu/api/v2/works/1b607dac-481a-43e8-a11f-3818a0b10e16?as=iiif"
+    )
+    
+    # Should return a single parsed entry (not a list)
+    assert parsed_item is not None, "Should create a parsed entry"
+    assert isinstance(parsed_item, dict), "Should return a dictionary, not a list"
+    
+    # Verify the structure matches the expected output
+    assert "text" in parsed_item, "Should have 'text' field"
+    assert "metadata" in parsed_item, "Should have 'metadata' field"
+    
+    metadata = parsed_item["metadata"]
+    expected_fields = ["id", "title", "type", "parent_collections", "homepage", "thumbnail", "rights", "attribution"]
+    for field in expected_fields:
+        assert field in metadata, f"Should have '{field}' field in metadata"
+    
+    # Verify specific values
+    assert metadata["title"] == "Single Manifest Test"
+    assert metadata["type"] == "Manifest"
+    assert metadata["id"] == "https://api.dc.library.northwestern.edu/api/v2/works/1b607dac-481a-43e8-a11f-3818a0b10e16?as=iiif"
+    assert metadata["homepage"] == "https://dc.library.northwestern.edu/items/1b607dac-481a-43e8-a11f-3818a0b10e16"
+    
+    # Verify parent collections
+    assert len(metadata["parent_collections"]) == 1
+    assert metadata["parent_collections"][0]["label"] == "Test Collection"
+    
+    # Verify attribution
+    attribution = metadata["attribution"]
+    assert attribution is not None
+    assert attribution["label"] == "Attribution"
+    assert "Northwestern University Libraries" in attribution["value"]
+    
+    # Verify text content
+    text = parsed_item["text"]
+    assert "Manifest ID:" in text
+    assert "Single Manifest Test" in text
+    assert "Test Collection" in text
+
+def test_parse_manifest_failed_manifest():
+    """Test parse_manifest with a manifest that fails to load"""
+    client = IIIFClient(no_cache=True)
+    
+    def mock_fetch_json(url):
+        return None  # Simulate failed fetch
+        
+    client.fetch_json = mock_fetch_json
+    
+    parsed_item = client.parse_manifest("https://example.org/broken-manifest")
+    
+    # Should return None for failed manifests
+    assert parsed_item is None, "Should return None for failed manifest"

--- a/uv.lock
+++ b/uv.lock
@@ -283,16 +283,16 @@ wheels = [
 
 [[package]]
 name = "iiif-prezi3"
-version = "2.0.0"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/fa/f7190c27a70863d4ec2751085ca6edf32ca107ffb6bccdcef35eb45bee43/iiif_prezi3-2.0.0.tar.gz", hash = "sha256:27365e10487701905fa432f72adc3e04f84f03fd5ad9bcfde0c99386669061f0", size = 29643 }
+sdist = { url = "https://files.pythonhosted.org/packages/16/48/93d241e130108750cfedb9d81dcc46fe70116f93e87fb3273ca14cde3c94/iiif_prezi3-2.0.2.tar.gz", hash = "sha256:f56006efae8575107c41f46517b5cad73c69f3a0f891727eb3f2f5e9e98d2d88", size = 32627 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/21/88d244b72dc76eb4fcba3d9cb4563c8e1af669bbb63ccfaf0fd3dbbfbd19/iiif_prezi3-2.0.0-py3-none-any.whl", hash = "sha256:e22f207ef8d0d1a4669560d4606953b4203c8506cab4a01266164ba57363c7e2", size = 27646 },
+    { url = "https://files.pythonhosted.org/packages/8b/b7/23a2676c2cf75f864831d7dbc7b0224c860b1315fae3e1560fe3cef48550/iiif_prezi3-2.0.2-py3-none-any.whl", hash = "sha256:4f628238ad5976269fda6235c2dd8d2eb04de7fb618c49103407393cff478d45", size = 28850 },
 ]
 
 [[package]]
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "loam-iiif"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -594,42 +594,42 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "1.10.21"
+version = "1.10.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/e9/d99a2c4f8f6d7c711f39f6ecf485b7f3bba66189bbbad505d24eb0106922/pydantic-1.10.21.tar.gz", hash = "sha256:64b48e2b609a6c22178a56c408ee1215a7206077ecb8a193e2fda31858b2362a", size = 356653 }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/57/5996c63f0deec09e9e901a2b838247c97c6844999562eac4e435bcb83938/pydantic-1.10.22.tar.gz", hash = "sha256:ee1006cebd43a8e7158fb7190bb8f4e2da9649719bff65d0c287282ec38dec6d", size = 356771 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/07/d416de2daba8088cb94ccf18c728e74c5194044106e3d0abfd1e80fe2f42/pydantic-1.10.21-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:245e486e0fec53ec2366df9cf1cba36e0bbf066af7cd9c974bbbd9ba10e1e586", size = 2852012 },
-    { url = "https://files.pythonhosted.org/packages/16/c3/d18f23da467f7e27b6149e45e631be61c80a71a461bec0935ba72a0e7a11/pydantic-1.10.21-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6c54f8d4c151c1de784c5b93dfbb872067e3414619e10e21e695f7bb84d1d1fd", size = 2585291 },
-    { url = "https://files.pythonhosted.org/packages/0c/ea/15356ef7057776b1d930539d28aeca9ab4f750385d6f7ad0732a38275030/pydantic-1.10.21-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b64708009cfabd9c2211295144ff455ec7ceb4c4fb45a07a804309598f36187", size = 3335851 },
-    { url = "https://files.pythonhosted.org/packages/ca/0d/cb79ab02376be10057e62075e6b6dfb902b90cf527d42a39521f917af984/pydantic-1.10.21-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a148410fa0e971ba333358d11a6dea7b48e063de127c2b09ece9d1c1137dde4", size = 3362493 },
-    { url = "https://files.pythonhosted.org/packages/ce/03/184c3df2b7f76fbe627d094e39f806c2ed6f445053ef18221c8092d5b96e/pydantic-1.10.21-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:36ceadef055af06e7756eb4b871cdc9e5a27bdc06a45c820cd94b443de019bbf", size = 3520020 },
-    { url = "https://files.pythonhosted.org/packages/ec/6b/2230fce10bf4af27705e7013d33d2e02f69c478a5e40a80efd65011b7af8/pydantic-1.10.21-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c0501e1d12df6ab1211b8cad52d2f7b2cd81f8e8e776d39aa5e71e2998d0379f", size = 3485291 },
-    { url = "https://files.pythonhosted.org/packages/2e/a1/3cf3978c8f9a2449069860703b9d597a6dd0ae7d3e0faacf9775e0b9dc63/pydantic-1.10.21-cp310-cp310-win_amd64.whl", hash = "sha256:c261127c275d7bce50b26b26c7d8427dcb5c4803e840e913f8d9df3f99dca55f", size = 2296751 },
-    { url = "https://files.pythonhosted.org/packages/f0/4f/b41e38ff64b6796d17add34c8346f7c63bae5caea3b0cb0f82f39f31de6f/pydantic-1.10.21-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8b6350b68566bb6b164fb06a3772e878887f3c857c46c0c534788081cb48adf4", size = 2845225 },
-    { url = "https://files.pythonhosted.org/packages/37/82/74d99737fb2b8694681c72f44558bed14d546bbe14e3ff29b93285749de8/pydantic-1.10.21-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:935b19fdcde236f4fbf691959fa5c3e2b6951fff132964e869e57c70f2ad1ba3", size = 2553041 },
-    { url = "https://files.pythonhosted.org/packages/c4/af/754cf630677fa5fcc438a67da8276f615e4c98046bb0095c95b1879151f3/pydantic-1.10.21-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b6a04efdcd25486b27f24c1648d5adc1633ad8b4506d0e96e5367f075ed2e0b", size = 3140462 },
-    { url = "https://files.pythonhosted.org/packages/04/80/d7b6655e3fa2ef838ede8646d7474baa27e05f49902b61b1638d5b89ec4f/pydantic-1.10.21-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c1ba253eb5af8d89864073e6ce8e6c8dec5f49920cff61f38f5c3383e38b1c9f", size = 3213698 },
-    { url = "https://files.pythonhosted.org/packages/1f/16/df08e4ce8c7eaa52903a7dd5e80cdcc8d7369f9732415cfa413fc0389a09/pydantic-1.10.21-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:57f0101e6c97b411f287a0b7cf5ebc4e5d3b18254bf926f45a11615d29475793", size = 3320976 },
-    { url = "https://files.pythonhosted.org/packages/c1/0f/f47794035ffca6d115666c02818f1d905e55dca3e3e470717416a9a6f07d/pydantic-1.10.21-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e85834f0370d737c77a386ce505c21b06bfe7086c1c568b70e15a568d9670d", size = 3243784 },
-    { url = "https://files.pythonhosted.org/packages/a7/3f/0ea126c922364f229946f8c49bfab075666cf584ea5b0b54aa3ad089cb85/pydantic-1.10.21-cp311-cp311-win_amd64.whl", hash = "sha256:6a497bc66b3374b7d105763d1d3de76d949287bf28969bff4656206ab8a53aa9", size = 2307305 },
-    { url = "https://files.pythonhosted.org/packages/5b/bd/abe17640066750dfcf4103065f9af149ba9868276a7d3936365db16dc546/pydantic-1.10.21-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ed4a5f13cf160d64aa331ab9017af81f3481cd9fd0e49f1d707b57fe1b9f3ae", size = 2794486 },
-    { url = "https://files.pythonhosted.org/packages/7b/d3/75a00f07e247b615002f9423d426191785850ff1bf947803f21b6bce952b/pydantic-1.10.21-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3b7693bb6ed3fbe250e222f9415abb73111bb09b73ab90d2d4d53f6390e0ccc1", size = 2534033 },
-    { url = "https://files.pythonhosted.org/packages/6f/65/1e61f78f6d3f2866bb93aa33260cf43cb650dedb403928394d498c7965dd/pydantic-1.10.21-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:185d5f1dff1fead51766da9b2de4f3dc3b8fca39e59383c273f34a6ae254e3e2", size = 2993618 },
-    { url = "https://files.pythonhosted.org/packages/f1/5c/28994d6b1ce73ed3946f2e08aee0f85d6a7bfc5469f5ea40f90c375a4dd7/pydantic-1.10.21-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:38e6d35cf7cd1727822c79e324fa0677e1a08c88a34f56695101f5ad4d5e20e5", size = 3036401 },
-    { url = "https://files.pythonhosted.org/packages/86/6b/ec8348dc64257feef791a8e31121e9e29d6d75731cdb914d9815c0677aa1/pydantic-1.10.21-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:1d7c332685eafacb64a1a7645b409a166eb7537f23142d26895746f628a3149b", size = 3171262 },
-    { url = "https://files.pythonhosted.org/packages/75/c4/901b81093ef73c93190c83e08acbef3ee2796a8d372bda7e8b57d0e94318/pydantic-1.10.21-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c9b782db6f993a36092480eeaab8ba0609f786041b01f39c7c52252bda6d85f", size = 3123215 },
-    { url = "https://files.pythonhosted.org/packages/5d/24/f56cc8bdb460872662199a19f4288cc2609f1911298e25f67a57f7397961/pydantic-1.10.21-cp312-cp312-win_amd64.whl", hash = "sha256:7ce64d23d4e71d9698492479505674c5c5b92cda02b07c91dfc13633b2eef805", size = 2189400 },
-    { url = "https://files.pythonhosted.org/packages/d4/79/717dc84083fbddc142efbd2bfe887edaf6b52cfd267b030849d43d7ed89a/pydantic-1.10.21-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0067935d35044950be781933ab91b9a708eaff124bf860fa2f70aeb1c4be7212", size = 2796872 },
-    { url = "https://files.pythonhosted.org/packages/79/88/63aa6efc8583e0a73d6d89e6534afd68917da66433a3b23f70ba229b37dc/pydantic-1.10.21-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5e8148c2ce4894ce7e5a4925d9d3fdce429fb0e821b5a8783573f3611933a251", size = 2538273 },
-    { url = "https://files.pythonhosted.org/packages/a5/d5/95b88740f8b9ce1b4884a682235db2f7f9327b071a294cf8b4b67beb37f1/pydantic-1.10.21-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4973232c98b9b44c78b1233693e5e1938add5af18042f031737e1214455f9b8", size = 2985789 },
-    { url = "https://files.pythonhosted.org/packages/dc/b3/5ffebe4951c9ab2a76e3644a3154545cdbf74a3465a60299af8978abdcec/pydantic-1.10.21-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:662bf5ce3c9b1cef32a32a2f4debe00d2f4839fefbebe1d6956e681122a9c839", size = 3015261 },
-    { url = "https://files.pythonhosted.org/packages/49/fb/9c2da63e3b407b3477276c9992fd4359c57483cb6aa760c0bceeabab1f3c/pydantic-1.10.21-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:98737c3ab5a2f8a85f2326eebcd214510f898881a290a7939a45ec294743c875", size = 3163989 },
-    { url = "https://files.pythonhosted.org/packages/05/a1/4c84b1ce488acd760e9ecd945b3c0ff6ecf1a26186f5eb058bab62d51d68/pydantic-1.10.21-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0bb58bbe65a43483d49f66b6c8474424d551a3fbe8a7796c42da314bac712738", size = 3117257 },
-    { url = "https://files.pythonhosted.org/packages/8a/a1/4ff39f2e89bf87496b9dc1aa56085848df971b341b14ad9e02a8bc13c966/pydantic-1.10.21-cp313-cp313-win_amd64.whl", hash = "sha256:e622314542fb48542c09c7bd1ac51d71c5632dd3c92dc82ede6da233f55f4848", size = 2172972 },
-    { url = "https://files.pythonhosted.org/packages/2d/a8/3e34e7127203ac002e1a5eb45108ef523d9196f75468fde5fdbec7544201/pydantic-1.10.21-py3-none-any.whl", hash = "sha256:db70c920cba9d05c69ad4a9e7f8e9e83011abb2c6490e561de9ae24aee44925c", size = 166430 },
+    { url = "https://files.pythonhosted.org/packages/88/92/91eb5c75a1460292e1f2f3e577122574ebb942fbac19ad2369ff00b9eb24/pydantic-1.10.22-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:57889565ccc1e5b7b73343329bbe6198ebc472e3ee874af2fa1865cfe7048228", size = 2852481 },
+    { url = "https://files.pythonhosted.org/packages/08/f3/dd54b49fc5caaed06f5a0d0a5ec35a81cf722cd6b42455f408dad1ef3f7d/pydantic-1.10.22-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:90729e22426de79bc6a3526b4c45ec4400caf0d4f10d7181ba7f12c01bb3897d", size = 2585586 },
+    { url = "https://files.pythonhosted.org/packages/ec/9b/48d10180cc614ffb66da486e99bc1f8b639fb44edf322864f2fb161e2351/pydantic-1.10.22-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8684d347f351554ec94fdcb507983d3116dc4577fb8799fed63c65869a2d10", size = 3336974 },
+    { url = "https://files.pythonhosted.org/packages/ff/80/b55ad0029ae8e7b8b5c81ad7c4e800774a52107d26f70c6696857dc733d5/pydantic-1.10.22-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c8dad498ceff2d9ef1d2e2bc6608f5b59b8e1ba2031759b22dfb8c16608e1802", size = 3362338 },
+    { url = "https://files.pythonhosted.org/packages/65/e0/8a5cd2cd29a5632581ba466f5792194b2a568aa052ce9da9ba98b634debf/pydantic-1.10.22-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fac529cc654d4575cf8de191cce354b12ba705f528a0a5c654de6d01f76cd818", size = 3519505 },
+    { url = "https://files.pythonhosted.org/packages/38/c5/c776d03ec374f22860802b2cee057b41e866be3c80826b53d4c001692db3/pydantic-1.10.22-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4148232aded8dd1dd13cf910a01b32a763c34bd79a0ab4d1ee66164fcb0b7b9d", size = 3485878 },
+    { url = "https://files.pythonhosted.org/packages/d1/a2/1efd064513a2c1bcb5c2b0e022cdf77d132ef7f7f20d91bb439d759f6a88/pydantic-1.10.22-cp310-cp310-win_amd64.whl", hash = "sha256:ece68105d9e436db45d8650dc375c760cc85a6793ae019c08769052902dca7db", size = 2299673 },
+    { url = "https://files.pythonhosted.org/packages/42/03/e435ed85a9abda29e3fbdb49c572fe4131a68c6daf3855a01eebda9e1b27/pydantic-1.10.22-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8e530a8da353f791ad89e701c35787418605d35085f4bdda51b416946070e938", size = 2845682 },
+    { url = "https://files.pythonhosted.org/packages/72/ea/4a625035672f6c06d3f1c7e33aa0af6bf1929991e27017e98b9c2064ae0b/pydantic-1.10.22-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:654322b85642e9439d7de4c83cb4084ddd513df7ff8706005dada43b34544946", size = 2553286 },
+    { url = "https://files.pythonhosted.org/packages/a4/f0/424ad837746e69e9f061ba9be68c2a97aef7376d1911692904d8efbcd322/pydantic-1.10.22-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8bece75bd1b9fc1c32b57a32831517943b1159ba18b4ba32c0d431d76a120ae", size = 3141232 },
+    { url = "https://files.pythonhosted.org/packages/14/67/4979c19e8cfd092085a292485e0b42d74e4eeefbb8cd726aa8ba38d06294/pydantic-1.10.22-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eccb58767f13c6963dcf96d02cb8723ebb98b16692030803ac075d2439c07b0f", size = 3214272 },
+    { url = "https://files.pythonhosted.org/packages/1a/04/32339ce43e97519d19e7759902515c750edbf4832a13063a4ab157f83f42/pydantic-1.10.22-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7778e6200ff8ed5f7052c1516617423d22517ad36cc7a3aedd51428168e3e5e8", size = 3321646 },
+    { url = "https://files.pythonhosted.org/packages/92/35/dffc1b29cb7198aadab68d75447191e59bdbc1f1d2d51826c9a4460d372f/pydantic-1.10.22-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bffe02767d27c39af9ca7dc7cd479c00dda6346bb62ffc89e306f665108317a2", size = 3244258 },
+    { url = "https://files.pythonhosted.org/packages/11/c5/c4ce6ebe7f528a879441eabd2c6dd9e2e4c54f320a8c9344ba93b3aa8701/pydantic-1.10.22-cp311-cp311-win_amd64.whl", hash = "sha256:23bc19c55427091b8e589bc08f635ab90005f2dc99518f1233386f46462c550a", size = 2309702 },
+    { url = "https://files.pythonhosted.org/packages/f6/a3/ec66239ed7c9e90edfb85b23b6b18eb290ed7aa05f54837cdcb6a14faa98/pydantic-1.10.22-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:92d0f97828a075a71d9efc65cf75db5f149b4d79a38c89648a63d2932894d8c9", size = 2794865 },
+    { url = "https://files.pythonhosted.org/packages/49/6a/99cf3fee612d93210c85f45a161e98c1c5b45b6dcadb21c9f1f838fa9e28/pydantic-1.10.22-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6af5a2811b6b95b58b829aeac5996d465a5f0c7ed84bd871d603cf8646edf6ff", size = 2534212 },
+    { url = "https://files.pythonhosted.org/packages/f1/e6/0f8882775cd9a60b221103ee7d6a89e10eb5a892d877c398df0da7140704/pydantic-1.10.22-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6cf06d8d40993e79af0ab2102ef5da77b9ddba51248e4cb27f9f3f591fbb096e", size = 2994027 },
+    { url = "https://files.pythonhosted.org/packages/e7/a3/f20fdecbaa2a2721a6a8ee9e4f344d1f72bd7d56e679371c3f2be15eb8c8/pydantic-1.10.22-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:184b7865b171a6057ad97f4a17fbac81cec29bd103e996e7add3d16b0d95f609", size = 3036716 },
+    { url = "https://files.pythonhosted.org/packages/1f/83/dab34436d830c38706685acc77219fc2a209fea2a2301a1b05a2865b28bf/pydantic-1.10.22-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:923ad861677ab09d89be35d36111156063a7ebb44322cdb7b49266e1adaba4bb", size = 3171801 },
+    { url = "https://files.pythonhosted.org/packages/1e/6e/b64deccb8a7304d584088972437ea3091e9d99d27a8e7bf2bd08e29ae84e/pydantic-1.10.22-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:82d9a3da1686443fb854c8d2ab9a473251f8f4cdd11b125522efb4d7c646e7bc", size = 3123560 },
+    { url = "https://files.pythonhosted.org/packages/08/9a/90d1ab704329a7ae8666354be84b5327d655764003974364767c9d307d3a/pydantic-1.10.22-cp312-cp312-win_amd64.whl", hash = "sha256:1612604929af4c602694a7f3338b18039d402eb5ddfbf0db44f1ebfaf07f93e7", size = 2191378 },
+    { url = "https://files.pythonhosted.org/packages/47/8f/67befe3607b342dd6eb80237134ebcc6e8db42138609306eaf2b30e1f273/pydantic-1.10.22-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b259dc89c9abcd24bf42f31951fb46c62e904ccf4316393f317abeeecda39978", size = 2797042 },
+    { url = "https://files.pythonhosted.org/packages/aa/91/bfde7d301f8e1c4cff949b3f1eb2c9b27bdd4b2368da0fe88e7350bbe4bc/pydantic-1.10.22-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9238aa0964d80c0908d2f385e981add58faead4412ca80ef0fa352094c24e46d", size = 2538572 },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/1b0097ece420354df77d2f01c72278fb43770c8ed732d6b7a303c0c70875/pydantic-1.10.22-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f8029f05b04080e3f1a550575a1bca747c0ea4be48e2d551473d47fd768fc1b", size = 2986271 },
+    { url = "https://files.pythonhosted.org/packages/eb/4c/e257edfd5a0025a428aee7a2835e21b51c76a6b1c8994bcccb14d5721eea/pydantic-1.10.22-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5c06918894f119e0431a36c9393bc7cceeb34d1feeb66670ef9b9ca48c073937", size = 3015617 },
+    { url = "https://files.pythonhosted.org/packages/00/17/ecf46ff31fd62d382424a07ed60540d4479094204bebeebb6dea597e88c3/pydantic-1.10.22-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e205311649622ee8fc1ec9089bd2076823797f5cd2c1e3182dc0e12aab835b35", size = 3164222 },
+    { url = "https://files.pythonhosted.org/packages/1a/47/2d55ec452c9a87347234bbbc70df268e1f081154b1851f0db89638558a1c/pydantic-1.10.22-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:815f0a73d5688d6dd0796a7edb9eca7071bfef961a7b33f91e618822ae7345b7", size = 3117572 },
+    { url = "https://files.pythonhosted.org/packages/03/2f/30359a36245b029bec7e442dd780fc242c66e66ad7dd5b50af2dcfd41ff3/pydantic-1.10.22-cp313-cp313-win_amd64.whl", hash = "sha256:9dfce71d42a5cde10e78a469e3d986f656afc245ab1b97c7106036f088dd91f8", size = 2174666 },
+    { url = "https://files.pythonhosted.org/packages/e9/e0/1ed151a56869be1588ad2d8cda9f8c1d95b16f74f09a7cea879ca9b63a8b/pydantic-1.10.22-py3-none-any.whl", hash = "sha256:343037d608bcbd34df937ac259708bfc83664dadf88afe8516c4f282d7d471a9", size = 166503 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add CLI version support from pyproject.toml
- Replace "chunk" terminology with "parse" throughout codebase
- Add parse_manifest() method for individual manifest processing
-  Update README with new parsing API documentation

Steps to test:
- Activate your `venv`:
```sh
source .venv/bin/activate
uv sync
```
- Run the tests with:
```sh
pytest
```
- Test the CLI versioning with:
```sh
loamiiif --version
loam-iiif, version 0.1.6
```
- Testing the parsing bugfix manually (`uv run python`):
```python
from loam_iiif.iiif import IIIFClient

client = IIIFClient()

manifest_data = client.parse_manifest(
    "https://api.dc.library.northwestern.edu/api/v2/works/1b607dac-481a-43e8-a11f-3818a0b10e16?as=iiif",
    strip_tags=True
)
print(manifest_data)
```