### PR TITLE
Fetch externally referenced text annotations per canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,60 @@ The structured data includes:
 - **parent_collections**: Information about collections this manifest belongs to
 - **homepage**: Direct link to the item's webpage (extracted from metadata or related fields)
 
+### Extracting Transcriptions (Per-Canvas)
+
+For manifests that include transcription annotations, `parse_manifest_canvases` returns one document per canvas rather than one per manifest. This is useful for RAG pipelines where page-level granularity produces better retrieval results. Canvases without transcriptions are skipped automatically.
+
+Both embedded annotation pages (items inline in the manifest) and referenced annotation pages (a stub that points to an external URL) are handled transparently.
+
+```python
+from loam_iiif.iiif import IIIFClient
+
+client = IIIFClient()
+
+canvas_docs = client.parse_manifest_canvases(
+    "https://example.org/manifest-with-transcriptions",
+    strip_tags=True
+)
+
+for doc in canvas_docs:
+    print(f"Canvas: {doc['metadata']['canvas_label']}")
+    print(f"Text:   {doc['text'][:100]}")
+```
+
+#### Per-Canvas Data Structure
+
+```python
+{
+    "text": "Transcription text for this canvas...",
+    "metadata": {
+        "canvas_id": "https://example.org/canvas/p1",
+        "canvas_label": "Page 1",
+        "manifest_id": "https://example.org/manifest",
+        "title": "Document Title",
+        "homepage": "https://example.org/item/123"
+    }
+}
+```
+
+#### Using with `parse_manifest` as a fallback
+
+For collections that mix transcribed and non-transcribed items, try canvases first and fall back to manifest-level parsing:
+
+```python
+client = IIIFClient()
+manifests, _ = client.get_manifests_and_collections_ids(collection_url)
+
+for manifest_url in manifests:
+    docs = client.parse_manifest_canvases(manifest_url)
+    if not docs:
+        doc = client.parse_manifest(manifest_url)
+        docs = [doc] if doc else []
+    for doc in docs:
+        # index doc in your vector database
+        pass
+```
+
 ### Getting Image URLs
 
 ```python

--- a/src/loam_iiif/iiif.py
+++ b/src/loam_iiif/iiif.py
@@ -856,7 +856,124 @@ class IIIFClient:
         else:
             logger.warning(f"Failed to parse manifest: {manifest_url}")
             return None
-    
+
+    def _resolve_annotation_page(self, anno_page: dict) -> List[dict]:
+        """
+        Returns annotation items from an AnnotationPage dict.
+
+        If the page has an inline 'items' list (embedded), returns it directly.
+        If it is a reference stub (has 'id' but no 'items'), fetches the external
+        URL and returns the items from the response.
+        """
+        items = anno_page.get("items")
+        if items is not None:
+            return items if isinstance(items, list) else []
+
+        page_id = anno_page.get("id") or anno_page.get("@id")
+        if not page_id:
+            return []
+
+        try:
+            data = self.fetch_json(page_id)
+            if isinstance(data, dict):
+                return data.get("items") or []
+        except Exception as e:
+            logger.warning(f"Failed to fetch external annotation page {page_id}: {e}")
+        return []
+
+    def _extract_canvas_transcription(self, canvas: dict, strip_tags: bool = True) -> Optional[str]:
+        """
+        Extracts transcription text from a canvas's 'annotations' property.
+
+        Only considers annotations with motivation 'supplementing' and a TextualBody.
+        Returns concatenated text from all matching annotations, or None if none found.
+        """
+        text_parts = []
+        for anno_page in canvas.get("annotations", []):
+            if not isinstance(anno_page, dict):
+                continue
+            for annotation in self._resolve_annotation_page(anno_page):
+                if not isinstance(annotation, dict):
+                    continue
+                motivation = annotation.get("motivation")
+                if motivation == "painting":
+                    continue
+                body = annotation.get("body")
+                if not isinstance(body, dict) or body.get("type") != "TextualBody":
+                    continue
+                value = body.get("value")
+                if value and isinstance(value, str):
+                    text = html.unescape(value)
+                    if strip_tags:
+                        text = re.sub(r'<[^>]+>', '', text)
+                    text = text.strip()
+                    if text:
+                        text_parts.append(text)
+        return "\n".join(text_parts) if text_parts else None
+
+    def parse_manifest_canvases(
+        self,
+        manifest_url: str,
+        strip_tags: bool = True
+    ) -> List[Dict[str, Any]]:
+        """
+        Parses a IIIF Manifest into per-canvas documents containing transcription text.
+
+        Returns one document per canvas that has supplementing annotations (transcriptions).
+        Canvases without transcriptions are skipped. Each document carries manifest-level
+        metadata as context for retrieval.
+
+        Handles both embedded AnnotationPages (items inline in the manifest) and referenced
+        AnnotationPages (stub with id only, items fetched from the external URL).
+
+        Args:
+            manifest_url (str): The URL of the IIIF Manifest to parse.
+            strip_tags (bool): If True (default), remove HTML tags from text fields.
+
+        Returns:
+            List of dicts, one per canvas with transcription text, each containing:
+              - text: transcription text for this canvas
+              - metadata: canvas_id, canvas_label, manifest_id, title, homepage
+        """
+        manifest_data = self.fetch_json(manifest_url)
+        if not isinstance(manifest_data, dict):
+            logger.warning(f"Failed to fetch manifest: {manifest_url}")
+            return []
+
+        manifest_id = self._normalize_item_id(manifest_data, manifest_url) or manifest_url
+        title = self._extract_iiif_text(manifest_data.get("label"), strip_tags=strip_tags)
+
+        homepage_url = None
+        homepage_data = manifest_data.get("homepage")
+        if isinstance(homepage_data, list) and homepage_data:
+            entry = homepage_data[0]
+            if isinstance(entry, dict):
+                homepage_url = entry.get("id")
+        elif isinstance(homepage_data, dict):
+            homepage_url = homepage_data.get("id") or homepage_data.get("@id")
+        elif isinstance(homepage_data, str):
+            homepage_url = homepage_data
+
+        results = []
+        for canvas in manifest_data.get("items", []):
+            if not isinstance(canvas, dict):
+                continue
+            transcription = self._extract_canvas_transcription(canvas, strip_tags=strip_tags)
+            if not transcription:
+                continue
+            results.append({
+                "text": transcription,
+                "metadata": {
+                    "canvas_id": self._normalize_item_id(canvas, manifest_url),
+                    "canvas_label": self._extract_iiif_text(canvas.get("label"), strip_tags=strip_tags),
+                    "manifest_id": manifest_id,
+                    "title": title,
+                    "homepage": homepage_url,
+                }
+            })
+
+        return results
+
     def get_manifest_images(self, manifest_url: str, width: int = 768, height: int = 2000, format: str = 'jpg', exact: bool = False, use_max: bool = False) -> List[str]:
         """
         Extract formatted image URLs from a manifest with specified dimensions.

--- a/test/fixtures/iiif_v3_manifest_embedded_annotations.json
+++ b/test/fixtures/iiif_v3_manifest_embedded_annotations.json
@@ -1,0 +1,63 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://example.org/manifest/1",
+  "type": "Manifest",
+  "label": {"en": ["Test Manifest with Embedded Annotations"]},
+  "homepage": [{"id": "https://example.org/item/1", "type": "Text"}],
+  "items": [
+    {
+      "id": "https://example.org/canvas/p1",
+      "type": "Canvas",
+      "label": {"en": ["Page 1"]},
+      "annotations": [
+        {
+          "id": "https://example.org/annotation-page/p1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://example.org/annotation/p1",
+              "type": "Annotation",
+              "motivation": "supplementing",
+              "body": {
+                "type": "TextualBody",
+                "value": "Transcription for page one.",
+                "language": "en"
+              },
+              "target": "https://example.org/canvas/p1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://example.org/canvas/p2",
+      "type": "Canvas",
+      "label": {"en": ["Page 2"]},
+      "annotations": [
+        {
+          "id": "https://example.org/annotation-page/p2",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://example.org/annotation/p2",
+              "type": "Annotation",
+              "motivation": "supplementing",
+              "body": {
+                "type": "TextualBody",
+                "value": "Transcription for page two.",
+                "language": "en"
+              },
+              "target": "https://example.org/canvas/p2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://example.org/canvas/p3",
+      "type": "Canvas",
+      "label": {"en": ["Page 3 (no transcription)"]},
+      "items": []
+    }
+  ]
+}

--- a/test/fixtures/iiif_v3_manifest_referenced_annotations.json
+++ b/test/fixtures/iiif_v3_manifest_referenced_annotations.json
@@ -1,0 +1,26 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://example.org/manifest/2",
+  "type": "Manifest",
+  "label": {"en": ["Test Manifest with Referenced Annotations"]},
+  "homepage": [{"id": "https://example.org/item/2", "type": "Text"}],
+  "items": [
+    {
+      "id": "https://example.org/canvas/r1",
+      "type": "Canvas",
+      "label": {"en": ["Page 1"]},
+      "annotations": [
+        {
+          "id": "https://example.org/annotation-page/r1",
+          "type": "AnnotationPage"
+        }
+      ]
+    },
+    {
+      "id": "https://example.org/canvas/r2",
+      "type": "Canvas",
+      "label": {"en": ["Page 2 (no transcription)"]},
+      "annotations": []
+    }
+  ]
+}

--- a/test/test_iiif.py
+++ b/test/test_iiif.py
@@ -2282,13 +2282,171 @@ def test_parse_manifest_single_manifest():
 def test_parse_manifest_failed_manifest():
     """Test parse_manifest with a manifest that fails to load"""
     client = IIIFClient(no_cache=True)
-    
+
     def mock_fetch_json(url):
         return None  # Simulate failed fetch
-        
+
     client.fetch_json = mock_fetch_json
-    
+
     parsed_item = client.parse_manifest("https://example.org/broken-manifest")
-    
+
     # Should return None for failed manifests
     assert parsed_item is None, "Should return None for failed manifest"
+
+
+def test_parse_manifest_canvases_embedded_annotations():
+    """Test parse_manifest_canvases with embedded (inline) annotation pages"""
+    client = IIIFClient(no_cache=True)
+    manifest_data = load_fixture("iiif_v3_manifest_embedded_annotations.json")
+
+    client.fetch_json = lambda url: manifest_data
+
+    results = client.parse_manifest_canvases("https://example.org/manifest/1")
+
+    # Two canvases have transcriptions; the third has none and should be skipped
+    assert len(results) == 2
+
+    assert results[0]["text"] == "Transcription for page one."
+    assert results[0]["metadata"]["canvas_id"] == "https://example.org/canvas/p1"
+    assert results[0]["metadata"]["canvas_label"] == "Page 1"
+    assert results[0]["metadata"]["manifest_id"] == "https://example.org/manifest/1"
+    assert results[0]["metadata"]["title"] == "Test Manifest with Embedded Annotations"
+    assert results[0]["metadata"]["homepage"] == "https://example.org/item/1"
+
+    assert results[1]["text"] == "Transcription for page two."
+    assert results[1]["metadata"]["canvas_id"] == "https://example.org/canvas/p2"
+
+
+def test_parse_manifest_canvases_referenced_annotations():
+    """Test parse_manifest_canvases fetches external referenced annotation pages"""
+    client = IIIFClient(no_cache=True)
+    manifest_data = load_fixture("iiif_v3_manifest_referenced_annotations.json")
+
+    external_annotation_page = {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        "id": "https://example.org/annotation-page/r1",
+        "type": "AnnotationPage",
+        "items": [
+            {
+                "id": "https://example.org/annotation/r1",
+                "type": "Annotation",
+                "motivation": "supplementing",
+                "body": {
+                    "type": "TextualBody",
+                    "value": "Transcription from external page.",
+                    "language": "en"
+                },
+                "target": "https://example.org/canvas/r1"
+            }
+        ]
+    }
+
+    def mock_fetch_json(url):
+        if url == "https://example.org/annotation-page/r1":
+            return external_annotation_page
+        return manifest_data
+
+    client.fetch_json = mock_fetch_json
+
+    results = client.parse_manifest_canvases("https://example.org/manifest/2")
+
+    # Only canvas r1 has a transcription; r2 has an empty annotations list
+    assert len(results) == 1
+    assert results[0]["text"] == "Transcription from external page."
+    assert results[0]["metadata"]["canvas_id"] == "https://example.org/canvas/r1"
+    assert results[0]["metadata"]["manifest_id"] == "https://example.org/manifest/2"
+    assert results[0]["metadata"]["title"] == "Test Manifest with Referenced Annotations"
+    assert results[0]["metadata"]["homepage"] == "https://example.org/item/2"
+
+
+def test_parse_manifest_canvases_skips_painting_motivation():
+    """Test that painting annotations are ignored; supplementing and commenting are included"""
+    client = IIIFClient(no_cache=True)
+
+    manifest_data = {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        "id": "https://example.org/manifest/3",
+        "type": "Manifest",
+        "label": {"en": ["Manifest"]},
+        "items": [
+            {
+                "id": "https://example.org/canvas/c1",
+                "type": "Canvas",
+                "label": {"en": ["Page 1"]},
+                "annotations": [
+                    {
+                        "id": "https://example.org/annotation-page/c1",
+                        "type": "AnnotationPage",
+                        "items": [
+                            {
+                                "id": "https://example.org/annotation/c1a",
+                                "type": "Annotation",
+                                "motivation": "painting",
+                                "body": {"type": "TextualBody", "value": "Should be ignored"},
+                                "target": "https://example.org/canvas/c1"
+                            },
+                            {
+                                "id": "https://example.org/annotation/c1b",
+                                "type": "Annotation",
+                                "motivation": "supplementing",
+                                "body": {"type": "TextualBody", "value": "Supplementing text"},
+                                "target": "https://example.org/canvas/c1"
+                            },
+                            {
+                                "id": "https://example.org/annotation/c1c",
+                                "type": "Annotation",
+                                "motivation": "commenting",
+                                "body": {"type": "TextualBody", "value": "Commenting text"},
+                                "target": "https://example.org/canvas/c1"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    client.fetch_json = lambda url: manifest_data
+
+    results = client.parse_manifest_canvases("https://example.org/manifest/3")
+
+    assert len(results) == 1
+    assert results[0]["text"] == "Supplementing text\nCommenting text"
+
+
+def test_parse_manifest_canvases_failed_external_fetch():
+    """Test that a failed external annotation page fetch is handled gracefully"""
+    client = IIIFClient(no_cache=True)
+    manifest_data = load_fixture("iiif_v3_manifest_referenced_annotations.json")
+
+    def mock_fetch_json(url):
+        if url == "https://example.org/annotation-page/r1":
+            raise requests.RequestException("Connection error")
+        return manifest_data
+
+    client.fetch_json = mock_fetch_json
+
+    # Should not raise; canvas with failed fetch is simply skipped
+    results = client.parse_manifest_canvases("https://example.org/manifest/2")
+    assert results == []
+
+
+def test_parse_manifest_canvases_no_annotations():
+    """Test parse_manifest_canvases returns empty list when no canvases have transcriptions"""
+    client = IIIFClient(no_cache=True)
+
+    manifest_data = {
+        "@context": "http://iiif.io/api/presentation/3/context.json",
+        "id": "https://example.org/manifest/4",
+        "type": "Manifest",
+        "label": {"en": ["No Transcriptions"]},
+        "items": [
+            {"id": "https://example.org/canvas/x1", "type": "Canvas", "items": []},
+            {"id": "https://example.org/canvas/x2", "type": "Canvas", "items": []}
+        ]
+    }
+
+    client.fetch_json = lambda url: manifest_data
+
+    results = client.parse_manifest_canvases("https://example.org/manifest/4")
+    assert results == []


### PR DESCRIPTION
### Summary

Adds support for IIIF manifests that include transcription annotations (as described in [IIIF Cookbook: Embedded or referenced Annotations](https://iiif.io/api/cookbook/recipe/0269-embedded-or-referenced-annotations/)). The new `parse_manifest_canvases` method returns one document per canvas containing transcription text plus manifest-level metadata, suitable for use as source documents in a RAG pipeline.

### Changes

  - Handles both embedded annotation pages (items inline in the manifest) and referenced annotation pages (stub with
  id only, items fetched from external URL)
  - Skips canvases with no transcription annotations, so single-canvas manifests behave the same as the existing parse_manifest output
  - Excludes painting annotations only; accepts `supplementing`, `commenting`, and any other motivation with a `TextualBody`
  - Existing `parse_manifest / create_manifest_data` behaviour is unchanged
  - Add test
  - Update README
